### PR TITLE
feat: add fraction display option for sympy and history log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+.env
+.venv
+venv/
+build/
+dist/
+*.egg-info/
+*.log
+.DS_Store
+.streamlit/

--- a/main.py
+++ b/main.py
@@ -12,6 +12,13 @@ import numpy as np
 import json
 import re
 import math
+import sys
+
+# allow converting extremely large integers to strings for advanced use cases
+try:
+    sys.set_int_max_str_digits(0)
+except AttributeError:
+    pass
 
 # LaTeX文字列を簡易的にSymPyで解釈できる形式へ変換
 def latex_to_sympy(expr: str) -> str:
@@ -19,6 +26,8 @@ def latex_to_sympy(expr: str) -> str:
     expr = expr.replace("\\left", "").replace("\\right", "")
     expr = re.sub(r"\\times", "*", expr)
     expr = re.sub(r"\\cdot", "*", expr)
+    while "**" in expr:
+        expr = expr.replace("**", "*")
     expr = re.sub(r"\\frac\{([^{}]+)\}\{([^{}]+)\}", r"(\1)/(\2)", expr)
     expr = expr.replace("^", "**")
     expr = expr.replace("{", "(").replace("}", ")")

--- a/main.py
+++ b/main.py
@@ -13,6 +13,18 @@ import json
 import re
 import math
 
+# LaTeX文字列を簡易的にSymPyで解釈できる形式へ変換
+def latex_to_sympy(expr: str) -> str:
+    """Convert a LaTeX math expression into a SymPy-parseable string."""
+    expr = expr.replace("\\left", "").replace("\\right", "")
+    expr = re.sub(r"\\times", "*", expr)
+    expr = re.sub(r"\\cdot", "*", expr)
+    expr = re.sub(r"\\frac\{([^{}]+)\}\{([^{}]+)\}", r"(\1)/(\2)", expr)
+    expr = expr.replace("^", "**")
+    expr = expr.replace("{", "(").replace("}", ")")
+    expr = expr.replace("\\", "")
+    return expr
+
 # SymPyの結果を分数や形式ごとに表示するユーティリティ
 def format_sympy_output(data, use_fraction=False, output_format="json_sympy"):
     """Recursively format SymPy outputs based on user preference and format."""
@@ -67,8 +79,16 @@ def display_response(response, use_fraction=False, output_format="json_sympy"):
 
 def parse_math_input(expr_str, input_format="SymPy"):
     """Parse math expression from SymPy or LaTeX format."""
+    if input_format == "LaTeX":
+        try:
+            return parse_latex(expr_str)
+        except Exception:
+            try:
+                return sympify(latex_to_sympy(expr_str))
+            except Exception as e:
+                raise ValueError(e)
     try:
-        return parse_latex(expr_str) if input_format == "LaTeX" else sympify(expr_str)
+        return sympify(expr_str)
     except Exception as e:
         raise ValueError(e)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+streamlit
+sympy
+scikit-learn
+seaborn
+matplotlib
+pandas
+numpy


### PR DESCRIPTION
## Summary
- add utility to format SymPy outputs and optionally show fractions
- add sidebar checkbox to toggle fraction display
- ensure all SymPy-based responses honor the fraction display setting
- allow LaTeX input parsing and customizable output formats for advanced users
- track up to 100 recent calculations and show raw/SymPy input-output history in the sidebar

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_688d8ba28ccc8321958d88c69a7afc9b