### PR TITLE
Add PyQt5 and Tkinter interfaces

### DIFF
--- a/gui_backend.py
+++ b/gui_backend.py
@@ -1,0 +1,157 @@
+import json
+from typing import Any, Dict, Tuple
+from main import (
+    factorize_equation,
+    complete_the_square,
+    calculate_combination,
+    calculate_permutation,
+    solve_user_equation,
+    solve_system_of_equations,
+    calculate_expression,
+    calculate_custom_expression,
+    calculate_days_remaining,
+    generate_random_numbers,
+    calculate_statistics,
+    perform_linear_regression,
+    stars_and_bars,
+    vector_operations,
+    matrix_operations,
+    solve_differential_equation,
+    sequence_analysis,
+    unit_conversion,
+    parse_math_input,
+    format_sympy_output
+)
+
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sympy import symbols
+
+SCIENTIFIC_DIGITS = 50
+
+# plotting helpers that return matplotlib figure objects
+
+def plot_functions_backend(funcs, x_min, x_max, points):
+    x_values = np.linspace(x_min, x_max, points)
+    fig, ax = plt.subplots()
+    for func in funcs:
+        y_values = []
+        for x in x_values:
+            y_values.append(eval(func.replace('^', '**').replace('x', str(x))))
+        ax.plot(x_values, y_values, label=func)
+    ax.legend()
+    ax.set_xlabel('x')
+    ax.set_ylabel('y')
+    return fig
+
+def plot_probability_distribution_backend(distribution, params):
+    x = np.linspace(params['x_min'], params['x_max'], 1000)
+    if distribution == '正規分布':
+        y = sns.norm.pdf(x, loc=params['mean'], scale=params['std_dev'])
+    elif distribution == '二項分布':
+        y = sns.binom.pmf(x, n=params['n'], p=params['p'])
+    elif distribution == 'ポアソン分布':
+        y = sns.poisson.pmf(x, mu=params['lambda'])
+    else:
+        raise ValueError('未知の分布です')
+    fig, ax = plt.subplots()
+    ax.plot(x, y)
+    ax.set_xlabel('x')
+    ax.set_ylabel('Probability')
+    return fig
+
+def draw_geometric_shape_backend(shape, params):
+    fig, ax = plt.subplots()
+    if shape == '円':
+        r = params['半径']
+        circle = plt.Circle((0,0), radius=r, fill=False)
+        ax.add_artist(circle)
+        ax.set_xlim(-r*1.2, r*1.2)
+        ax.set_ylim(-r*1.2, r*1.2)
+    elif shape == '三角形':
+        tri = plt.Polygon(params['頂点'], fill=False)
+        ax.add_artist(tri)
+        ax.set_xlim(-1,1)
+        ax.set_ylim(-1,1)
+    ax.set_aspect('equal','box')
+    return fig
+
+# format output for GUI display
+
+def format_response(response: Any, use_fraction: bool, output_format: str, use_scientific: bool) -> str:
+    formatted = format_sympy_output(response, use_fraction, output_format, use_scientific)
+    if isinstance(formatted, (dict, list)):
+        return json.dumps(formatted, ensure_ascii=False, indent=2)
+    return str(formatted)
+
+# execution dispatcher
+
+def run_feature(name: str, params: Dict[str, Any], opts: Dict[str, Any]) -> Tuple[str, Any]:
+    """Run a feature and return (text, figure)."""
+    fig = None
+    if name == '因数分解':
+        res = factorize_equation(params['equation'], opts['input_format'])
+    elif name == '平方完成':
+        res = complete_the_square(params['equation'], opts['input_format'])
+    elif name == '組合せの計算':
+        res = calculate_combination(int(params['n']), int(params['m']))
+    elif name == '順列の計算':
+        res = calculate_permutation(int(params['n']), int(params['m']))
+    elif name == '方程式':
+        res = solve_user_equation(params['equation'], opts['input_format'])
+    elif name == '連立方程式':
+        res = solve_system_of_equations(params['equations'], opts['input_format'])
+    elif name == '式の計算':
+        res = calculate_expression(params['expression'], opts['input_format'])
+    elif name == 'カスタム式の計算':
+        res = calculate_custom_expression(params['expression'], opts['input_format'])
+    elif name == '日数の計算':
+        res = calculate_days_remaining(params['date'])
+    elif name == 'ランダム数の生成':
+        res = generate_random_numbers(float(params['start']), float(params['end']), int(params['samples']))
+    elif name == '統計の計算':
+        data = [float(x.strip()) for x in params['data'].split(',') if x.strip()]
+        res = calculate_statistics(data)
+    elif name == '線形回帰の実行':
+        rows = [line.split(',') for line in params['data'].strip().split('\n') if line.strip()]
+        data = [[float(a), float(b)] for a,b in rows]
+        res = perform_linear_regression(data)
+    elif name == '関数のプロット':
+        funcs = [f.strip() for f in params['functions'].split(',') if f.strip()]
+        fig = plot_functions_backend(funcs, float(params['x_min']), float(params['x_max']), int(params['points']))
+        res = {'status': 'plotted'}
+    elif name == 'Stars and Bars':
+        res = stars_and_bars(int(params['n']), int(params['k']))
+    elif name == 'ベクトル演算':
+        v1 = [float(x) for x in params['v1'].split(',')]
+        v2 = [float(x) for x in params['v2'].split(',')]
+        res = vector_operations(v1, v2, params['operation'])
+    elif name == '行列演算':
+        m1 = [list(map(float, row.split(','))) for row in params['m1'].split(';')]
+        m2 = [list(map(float, row.split(','))) for row in params['m2'].split(';')]
+        res = matrix_operations(m1, m2, params['operation'])
+    elif name == '微分方程式の解法':
+        dep = symbols(params['dependent'])
+        res = solve_differential_equation(params['equation'], dep, opts['input_format'])
+    elif name == '数列の解析':
+        seq = [float(x.strip()) for x in params['sequence'].split(',') if x.strip()]
+        res = sequence_analysis(seq)
+    elif name == '単位変換':
+        res = unit_conversion(float(params['value']), params['from_unit'], params['to_unit'])
+    elif name == '幾何学的図形の描画と計算':
+        shape = params['shape']
+        if shape == '円':
+            fig = draw_geometric_shape_backend(shape, {'半径': float(params['radius'])})
+        elif shape == '三角形':
+            pts = []
+            for line in params['vertices'].strip().split('\n'):
+                x,y = map(float, line.split(','))
+                pts.append((x,y))
+            fig = draw_geometric_shape_backend(shape, {'頂点': pts})
+        res = {'status': 'plotted'}
+    else:
+        raise ValueError(f'未対応の機能: {name}')
+
+    text = format_response(res, opts['use_fraction'], opts['output_format'], opts['use_scientific'])
+    return text, fig

--- a/pyqt.main.py
+++ b/pyqt.main.py
@@ -1,0 +1,153 @@
+import sys
+import json
+from PyQt5.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QFormLayout, QLineEdit,
+    QTextEdit, QPushButton, QComboBox, QCheckBox, QLabel
+)
+from PyQt5.QtCore import Qt
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+
+from gui_backend import run_feature
+
+FEATURE_FIELDS = {
+    '因数分解': [('equation', '式')],
+    '平方完成': [('equation', '式')],
+    '組合せの計算': [('n', 'n'), ('m', 'm')],
+    '順列の計算': [('n', 'n'), ('m', 'm')],
+    '方程式': [('equation', '方程式')],
+    '連立方程式': [('equations', '方程式 (カンマ区切り)')],
+    '式の計算': [('expression', '式')],
+    'カスタム式の計算': [('expression', '式')],
+    '日数の計算': [('date', '日付(YYYY-MM-DD)')],
+    'ランダム数の生成': [('start', '開始'), ('end', '終了'), ('samples', 'サンプル数')],
+    '統計の計算': [('data', 'データ(カンマ区切り)')],
+    '線形回帰の実行': [('data', 'データ(x,y 各行)')],
+    '関数のプロット': [('functions', '関数 (カンマ区切り)'), ('x_min', 'x最小'), ('x_max', 'x最大'), ('points', '分割数')],
+    'Stars and Bars': [('n', 'n'), ('k', 'k')],
+    'ベクトル演算': [('v1', 'ベクトル1'), ('v2', 'ベクトル2'), ('operation', '演算:加算,減算,内積,外積')],
+    '行列演算': [('m1', '行列1'), ('m2', '行列2'), ('operation', '演算:加算,減算,乗算,逆行列,行列式')],
+    '微分方程式の解法': [('equation', '方程式'), ('dependent', '従属変数')],
+    '数列の解析': [('sequence', '数列(カンマ区切り)')],
+    '単位変換': [('value', '値'), ('from_unit', '変換元(m,km)'), ('to_unit', '変換先(km,m)')],
+    '幾何学的図形の描画と計算': [('shape', '図形(円/三角形)'), ('radius', '半径'), ('vertices', '頂点(x,y 各行)')]
+}
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("PyQt5 Math GUI")
+        self.inputs = {}
+
+        central = QWidget()
+        self.setCentralWidget(central)
+        main_layout = QVBoxLayout()
+        central.setLayout(main_layout)
+
+        # options
+        opt_layout = QFormLayout()
+        self.use_fraction = QCheckBox("結果を分数で表示")
+        self.use_scientific = QCheckBox("指数表示")
+        self.use_scientific.setChecked(True)
+        self.input_format = QComboBox(); self.input_format.addItems(["SymPy", "LaTeX"])
+        self.output_format = QComboBox(); self.output_format.addItems(["json_sympy", "json_latex", "latex_render", "raw_sympy"])
+        opt_layout.addRow(self.use_fraction)
+        opt_layout.addRow(self.use_scientific)
+        opt_layout.addRow(QLabel("入力形式"), self.input_format)
+        opt_layout.addRow(QLabel("出力形式"), self.output_format)
+        main_layout.addLayout(opt_layout)
+
+        # feature selection
+        self.feature_combo = QComboBox()
+        self.feature_combo.addItems(FEATURE_FIELDS.keys())
+        self.feature_combo.currentTextChanged.connect(self.build_form)
+        main_layout.addWidget(self.feature_combo)
+
+        # dynamic form
+        self.form_layout = QFormLayout()
+        main_layout.addLayout(self.form_layout)
+
+        # run button
+        self.run_btn = QPushButton("実行")
+        self.run_btn.clicked.connect(self.execute)
+        main_layout.addWidget(self.run_btn)
+
+        # output
+        self.output = QTextEdit()
+        self.output.setReadOnly(True)
+        main_layout.addWidget(self.output)
+
+        # figure canvas
+        self.canvas = FigureCanvas(Figure())
+        main_layout.addWidget(self.canvas)
+        self.canvas.hide()
+
+        self.build_form(self.feature_combo.currentText())
+
+    def build_form(self, name):
+        # clear
+        while self.form_layout.count():
+            item = self.form_layout.takeAt(0)
+            w = item.widget()
+            if w:
+                w.deleteLater()
+        self.inputs = {}
+        for key, label in FEATURE_FIELDS[name]:
+            if key in ('operation', 'from_unit', 'to_unit', 'shape'):
+                combo = QComboBox()
+                if key == 'operation' and 'ベクトル演算' in name:
+                    combo.addItems(['加算','減算','内積','外積'])
+                elif key == 'operation':
+                    combo.addItems(['加算','減算','乗算','逆行列','行列式'])
+                elif key == 'from_unit':
+                    combo.addItems(['m','km'])
+                elif key == 'to_unit':
+                    combo.addItems(['km','m'])
+                elif key == 'shape':
+                    combo.addItems(['円','三角形'])
+                self.form_layout.addRow(QLabel(label), combo)
+                self.inputs[key] = combo
+            elif key == 'vertices':
+                text = QTextEdit()
+                self.form_layout.addRow(QLabel(label), text)
+                self.inputs[key] = text
+            else:
+                line = QLineEdit()
+                self.form_layout.addRow(QLabel(label), line)
+                self.inputs[key] = line
+
+    def execute(self):
+        name = self.feature_combo.currentText()
+        params = {}
+        for key, widget in self.inputs.items():
+            if isinstance(widget, QLineEdit):
+                params[key] = widget.text()
+            elif isinstance(widget, QTextEdit):
+                params[key] = widget.toPlainText()
+            elif isinstance(widget, QComboBox):
+                params[key] = widget.currentText()
+        opts = {
+            'use_fraction': self.use_fraction.isChecked(),
+            'use_scientific': self.use_scientific.isChecked(),
+            'input_format': self.input_format.currentText(),
+            'output_format': self.output_format.currentText()
+        }
+        try:
+            text, fig = run_feature(name, params, opts)
+            self.output.setText(text)
+            if fig:
+                self.canvas.figure = fig
+                self.canvas.draw()
+                self.canvas.show()
+            else:
+                self.canvas.hide()
+        except Exception as e:
+            self.output.setText(f"Error: {e}")
+            self.canvas.hide()
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    win = MainWindow()
+    win.resize(800, 600)
+    win.show()
+    sys.exit(app.exec_())

--- a/pyqt.main.py
+++ b/pyqt.main.py
@@ -2,7 +2,7 @@ import sys
 import json
 from PyQt5.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QFormLayout, QLineEdit,
-    QTextEdit, QPushButton, QComboBox, QCheckBox, QLabel
+    QTextEdit, QPushButton, QComboBox, QCheckBox, QLabel, QSplitter
 )
 from PyQt5.QtCore import Qt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
@@ -39,12 +39,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("PyQt5 Math GUI")
         self.inputs = {}
 
-        central = QWidget()
-        self.setCentralWidget(central)
-        main_layout = QVBoxLayout()
-        central.setLayout(main_layout)
-
-        # options
+        # left panel widgets
         opt_layout = QFormLayout()
         self.use_fraction = QCheckBox("結果を分数で表示")
         self.use_scientific = QCheckBox("指数表示")
@@ -55,32 +50,43 @@ class MainWindow(QMainWindow):
         opt_layout.addRow(self.use_scientific)
         opt_layout.addRow(QLabel("入力形式"), self.input_format)
         opt_layout.addRow(QLabel("出力形式"), self.output_format)
-        main_layout.addLayout(opt_layout)
 
-        # feature selection
         self.feature_combo = QComboBox()
         self.feature_combo.addItems(FEATURE_FIELDS.keys())
         self.feature_combo.currentTextChanged.connect(self.build_form)
-        main_layout.addWidget(self.feature_combo)
 
-        # dynamic form
         self.form_layout = QFormLayout()
-        main_layout.addLayout(self.form_layout)
 
-        # run button
         self.run_btn = QPushButton("実行")
         self.run_btn.clicked.connect(self.execute)
-        main_layout.addWidget(self.run_btn)
 
-        # output
+        left_panel = QWidget()
+        left_panel.setMinimumWidth(250)
+        left_layout = QVBoxLayout(left_panel)
+        left_layout.addLayout(opt_layout)
+        left_layout.addWidget(self.feature_combo)
+        left_layout.addLayout(self.form_layout)
+        left_layout.addWidget(self.run_btn)
+        left_layout.addStretch()
+
+        # right panel widgets
         self.output = QTextEdit()
         self.output.setReadOnly(True)
-        main_layout.addWidget(self.output)
-
-        # figure canvas
         self.canvas = FigureCanvas(Figure())
-        main_layout.addWidget(self.canvas)
         self.canvas.hide()
+        right_splitter = QSplitter(Qt.Vertical)
+        right_splitter.addWidget(self.output)
+        right_splitter.addWidget(self.canvas)
+        right_splitter.setStretchFactor(0, 3)
+        right_splitter.setStretchFactor(1, 2)
+
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.addWidget(left_panel)
+        splitter.addWidget(right_splitter)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+
+        self.setCentralWidget(splitter)
 
         self.build_form(self.feature_combo.currentText())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ seaborn
 matplotlib
 pandas
 numpy
+
+PyQt5

--- a/tk.main.py
+++ b/tk.main.py
@@ -34,7 +34,14 @@ class App(tk.Tk):
         self.title("Tkinter Math GUI")
         self.inputs = {}
 
-        option_frame = ttk.Frame(self)
+        main_pane = tk.PanedWindow(self, orient=tk.HORIZONTAL)
+        main_pane.pack(fill='both', expand=True)
+
+        # left sidebar
+        left = ttk.Frame(main_pane, width=250)
+        main_pane.add(left, minsize=200)
+
+        option_frame = ttk.Frame(left)
         option_frame.pack(fill='x')
         self.use_fraction = tk.BooleanVar()
         self.use_scientific = tk.BooleanVar(value=True)
@@ -49,18 +56,25 @@ class App(tk.Tk):
         self.output_format.current(0)
         self.output_format.pack(side='left')
 
-        self.feature = ttk.Combobox(self, values=list(FEATURE_FIELDS.keys()))
+        self.feature = ttk.Combobox(left, values=list(FEATURE_FIELDS.keys()))
         self.feature.current(0)
         self.feature.pack(fill='x')
         self.feature.bind("<<ComboboxSelected>>", lambda e: self.build_form())
 
-        self.form = ttk.Frame(self)
-        self.form.pack(fill='x')
+        self.form = ttk.Frame(left)
+        self.form.pack(fill='both', expand=True)
 
-        ttk.Button(self, text="実行", command=self.execute).pack(fill='x')
+        ttk.Button(left, text="実行", command=self.execute).pack(fill='x')
 
-        self.output = scrolledtext.ScrolledText(self, height=10)
-        self.output.pack(fill='both', expand=True)
+        # right pane for output and figures
+        right_pane = tk.PanedWindow(main_pane, orient=tk.VERTICAL)
+        main_pane.add(right_pane)
+
+        self.output = scrolledtext.ScrolledText(right_pane, height=10)
+        right_pane.add(self.output)
+
+        self.fig_frame = ttk.Frame(right_pane)
+        right_pane.add(self.fig_frame)
 
         self.fig_canvas = None
 
@@ -119,7 +133,7 @@ class App(tk.Tk):
             if fig:
                 if self.fig_canvas:
                     self.fig_canvas.get_tk_widget().destroy()
-                self.fig_canvas = FigureCanvasTkAgg(fig, master=self)
+                self.fig_canvas = FigureCanvasTkAgg(fig, master=self.fig_frame)
                 self.fig_canvas.get_tk_widget().pack(fill='both', expand=True)
                 self.fig_canvas.draw()
             elif self.fig_canvas:

--- a/tk.main.py
+++ b/tk.main.py
@@ -1,0 +1,138 @@
+import tkinter as tk
+from tkinter import ttk, scrolledtext
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.figure import Figure
+
+from gui_backend import run_feature
+
+FEATURE_FIELDS = {
+    '因数分解': [('equation', '式')],
+    '平方完成': [('equation', '式')],
+    '組合せの計算': [('n', 'n'), ('m', 'm')],
+    '順列の計算': [('n', 'n'), ('m', 'm')],
+    '方程式': [('equation', '方程式')],
+    '連立方程式': [('equations', '方程式 (カンマ区切り)')],
+    '式の計算': [('expression', '式')],
+    'カスタム式の計算': [('expression', '式')],
+    '日数の計算': [('date', '日付(YYYY-MM-DD)')],
+    'ランダム数の生成': [('start', '開始'), ('end', '終了'), ('samples', 'サンプル数')],
+    '統計の計算': [('data', 'データ(カンマ区切り)')],
+    '線形回帰の実行': [('data', 'データ(x,y 各行)')],
+    '関数のプロット': [('functions', '関数 (カンマ区切り)'), ('x_min', 'x最小'), ('x_max', 'x最大'), ('points', '分割数')],
+    'Stars and Bars': [('n', 'n'), ('k', 'k')],
+    'ベクトル演算': [('v1', 'ベクトル1'), ('v2', 'ベクトル2'), ('operation', '演算:加算,減算,内積,外積')],
+    '行列演算': [('m1', '行列1'), ('m2', '行列2'), ('operation', '演算:加算,減算,乗算,逆行列,行列式')],
+    '微分方程式の解法': [('equation', '方程式'), ('dependent', '従属変数')],
+    '数列の解析': [('sequence', '数列(カンマ区切り)')],
+    '単位変換': [('value', '値'), ('from_unit', '変換元(m,km)'), ('to_unit', '変換先(km,m)')],
+    '幾何学的図形の描画と計算': [('shape', '図形(円/三角形)'), ('radius', '半径'), ('vertices', '頂点(x,y 各行)')]
+}
+
+class App(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Tkinter Math GUI")
+        self.inputs = {}
+
+        option_frame = ttk.Frame(self)
+        option_frame.pack(fill='x')
+        self.use_fraction = tk.BooleanVar()
+        self.use_scientific = tk.BooleanVar(value=True)
+        ttk.Checkbutton(option_frame, text="結果を分数で表示", variable=self.use_fraction).pack(side='left')
+        ttk.Checkbutton(option_frame, text="指数表示", variable=self.use_scientific).pack(side='left')
+        ttk.Label(option_frame, text="入力形式").pack(side='left')
+        self.input_format = ttk.Combobox(option_frame, values=["SymPy","LaTeX"], width=7)
+        self.input_format.current(0)
+        self.input_format.pack(side='left')
+        ttk.Label(option_frame, text="出力形式").pack(side='left')
+        self.output_format = ttk.Combobox(option_frame, values=["json_sympy","json_latex","latex_render","raw_sympy"], width=10)
+        self.output_format.current(0)
+        self.output_format.pack(side='left')
+
+        self.feature = ttk.Combobox(self, values=list(FEATURE_FIELDS.keys()))
+        self.feature.current(0)
+        self.feature.pack(fill='x')
+        self.feature.bind("<<ComboboxSelected>>", lambda e: self.build_form())
+
+        self.form = ttk.Frame(self)
+        self.form.pack(fill='x')
+
+        ttk.Button(self, text="実行", command=self.execute).pack(fill='x')
+
+        self.output = scrolledtext.ScrolledText(self, height=10)
+        self.output.pack(fill='both', expand=True)
+
+        self.fig_canvas = None
+
+        self.build_form()
+
+    def build_form(self):
+        for child in self.form.winfo_children():
+            child.destroy()
+        self.inputs = {}
+        for key, label in FEATURE_FIELDS[self.feature.get()]:
+            ttk.Label(self.form, text=label).pack(anchor='w')
+            if key in ('operation', 'from_unit', 'to_unit', 'shape'):
+                if key == 'operation' and 'ベクトル演算' in self.feature.get():
+                    values = ['加算','減算','内積','外積']
+                elif key == 'operation':
+                    values = ['加算','減算','乗算','逆行列','行列式']
+                elif key == 'from_unit':
+                    values = ['m','km']
+                elif key == 'to_unit':
+                    values = ['km','m']
+                elif key == 'shape':
+                    values = ['円','三角形']
+                cb = ttk.Combobox(self.form, values=values)
+                cb.current(0)
+                cb.pack(fill='x')
+                self.inputs[key] = cb
+            elif key == 'vertices':
+                txt = scrolledtext.ScrolledText(self.form, height=4)
+                txt.pack(fill='x')
+                self.inputs[key] = txt
+            else:
+                entry = ttk.Entry(self.form)
+                entry.pack(fill='x')
+                self.inputs[key] = entry
+
+    def execute(self):
+        name = self.feature.get()
+        params = {}
+        for key, widget in self.inputs.items():
+            if isinstance(widget, ttk.Entry):
+                params[key] = widget.get()
+            elif isinstance(widget, ttk.Combobox):
+                params[key] = widget.get()
+            else:
+                params[key] = widget.get("1.0", tk.END).strip()
+        opts = {
+            'use_fraction': self.use_fraction.get(),
+            'use_scientific': self.use_scientific.get(),
+            'input_format': self.input_format.get(),
+            'output_format': self.output_format.get()
+        }
+        try:
+            text, fig = run_feature(name, params, opts)
+            self.output.delete('1.0', tk.END)
+            self.output.insert(tk.END, text)
+            if fig:
+                if self.fig_canvas:
+                    self.fig_canvas.get_tk_widget().destroy()
+                self.fig_canvas = FigureCanvasTkAgg(fig, master=self)
+                self.fig_canvas.get_tk_widget().pack(fill='both', expand=True)
+                self.fig_canvas.draw()
+            elif self.fig_canvas:
+                self.fig_canvas.get_tk_widget().destroy()
+                self.fig_canvas = None
+        except Exception as e:
+            self.output.delete('1.0', tk.END)
+            self.output.insert(tk.END, f"Error: {e}")
+            if self.fig_canvas:
+                self.fig_canvas.get_tk_widget().destroy()
+                self.fig_canvas = None
+
+if __name__ == '__main__':
+    app = App()
+    app.geometry('800x600')
+    app.mainloop()


### PR DESCRIPTION
## Summary
- add shared backend for GUI math operations
- introduce PyQt5 desktop interface with customizable settings
- include Tkinter interface with plotting support

## Testing
- `python -m py_compile gui_backend.py pyqt.main.py tk.main.py`


------
https://chatgpt.com/codex/tasks/task_e_688e05f952d883219cca92e843af2f95